### PR TITLE
Test lib now in .tmp/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ build/Release
 # see https://npmjs.org/doc/faq.html#Should-I-check-my-node_modules-folder-into-git
 node_modules
 bower_components
+.tmp

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -14,6 +14,10 @@ module.exports = function(grunt) {
       radio: {
         src: 'src/wrapper.js',
         dest: 'build/backbone.radio.js'
+      },
+      test: {
+        src: 'src/wrapper.js',
+        dest: '.tmp/backbone.radio.js'
       }
     },
 
@@ -69,9 +73,9 @@ module.exports = function(grunt) {
     }
   });
 
-  grunt.registerTask('test', 'Test the library', ['build', 'jshint', 'mocha']);
+  grunt.registerTask('test', 'Test the library', ['preprocess:test', 'jshint', 'mocha']);
 
-  grunt.registerTask('build', 'Build the library', ['preprocess', 'template', 'concat', 'uglify']);
+  grunt.registerTask('build', 'Build the library', ['test', 'preprocess:radio', 'template', 'concat', 'uglify']);
 
   grunt.registerTask('default', 'An alias of test', ['test']);
 };

--- a/test/index.html
+++ b/test/index.html
@@ -28,7 +28,7 @@
   <script src='../bower_components/backbone/backbone.js'></script>
 
   <!-- Load the test scripts -->
-  <script src='../build/backbone.radio.js'></script>
+  <script src='../.tmp/backbone.radio.js'></script>
 
   <!-- Of course, the specs themselves as well -->
   <script src='spec/form.js'></script>


### PR DESCRIPTION
Previously my tests were against the built version of the lib. This was problematic because every PR included a new built lib. This fixes that so the tests are against a file in `.tmp/`
