### PR TITLE
Refactor tests

### DIFF
--- a/test/.jshintrc
+++ b/test/.jshintrc
@@ -20,7 +20,6 @@
   "trailing"      : true,
   "maxparams"     : 4,
   "maxdepth"      : 2,
-  "maxstatements" : 15,
   "maxcomplexity" : 10,
   "maxlen"        : 120,
 

--- a/test/index.html
+++ b/test/index.html
@@ -21,6 +21,16 @@
   <script src='../bower_components/sinonjs/sinon.js'></script>
   <script>
     var expect = chai.expect;
+
+    beforeEach(function() {
+      this.sinon = sinon.sandbox.create();
+    });
+
+    afterEach(function() {
+      Backbone.Radio.DEBUG = false;
+      _.invoke(Backbone.Radio._channels, 'reset');
+      this.sinon.restore();
+    });
   </script>
 
   <!-- Load any dependencies (bower components) -->

--- a/test/spec/channel.js
+++ b/test/spec/channel.js
@@ -1,175 +1,135 @@
 describe('When calling Radio.channel with no name', function() {
-  var channelStub;
-
   beforeEach(function() {
-    channelStub = sinon.spy(Backbone.Radio, 'channel');
-  });
-
-  afterEach(function() {
-    channelStub.restore();
+    this.channelStub = this.sinon.spy(Backbone.Radio, 'channel');
   });
 
   it('should throw an error', function() {
-    expect(channelStub).to.throw(Error, 'You must provide a name for the channel.');
+    expect(this.channelStub).to.throw(Error, 'You must provide a name for the channel.');
   });
 });
 
 describe('Upon creation, a Channel', function() {
-  var channel, channelName, name = 'test',
-  eventKeys, requestKeys, commandKeys, channelKeys,
-  eventIntersect, requestIntersect, commandIntersect;
-
   beforeEach(function() {
-    channel = new Backbone.Radio.Channel(name);
-    channelName = channel._channelName;
+    this.name = 'foobar';
+    this.channel = new Backbone.Radio.Channel(this.name);
 
-    channelKeys = _.keys(channel);
+    this.channelName = this.channel._channelName;
+    this.channelKeys = _.keys(this.channel);
+    this.eventKeys   = _.keys(Backbone.Events);
+    this.requestKeys = _.keys(Backbone.Radio.Requests);
+    this.commandKeys = _.keys(Backbone.Radio.Commands);
 
-    eventKeys = _.keys(Backbone.Events);
-    requestKeys = _.keys(Backbone.Radio.Requests);
-    commandKeys = _.keys(Backbone.Radio.Commands);
-
-    eventIntersect = _.intersection(eventKeys, channelKeys);
-    requestIntersect = _.intersection(requestKeys, channelKeys);
-    commandIntersect = _.intersection(commandKeys, channelKeys);
+    this.eventIntersect   = _.intersection(this.eventKeys, this.channelKeys);
+    this.requestIntersect = _.intersection(this.requestKeys, this.channelKeys);
+    this.commandIntersect = _.intersection(this.commandKeys, this.channelKeys);
   });
 
   it('should have its name set', function() {
-    expect(channelName).to.equal(name);
+    expect(this.channelName).to.equal(this.name);
   });
 
   it('should have all of the Backbone.Events methods', function() {
-    expect(eventIntersect.length).to.equal(eventKeys.length);
+    expect(this.eventIntersect.length).to.equal(this.eventKeys.length);
   });
 
   it('should have all of the Radio.Commands methods', function() {
-    expect(commandIntersect.length).to.equal(commandKeys.length);
+    expect(this.commandIntersect.length).to.equal(this.commandKeys.length);
   });
 
   it('should have all of the Radio.Requests methods', function() {
-    expect(requestIntersect.length).to.equal(requestKeys.length);
+    expect(this.requestIntersect.length).to.equal(this.requestKeys.length);
   });
 });
 
 describe('Executing the `reset` method of a Channel', function() {
-  
-  var channel, returned,
-  offStub, stopListeningStub,
-  stopReactingStub, stopRespondingStub;
-
   beforeEach(function() {
-    channel = new Backbone.Radio.Channel('test');
-    offStub = sinon.stub(channel, 'off');
-    stopListeningStub = sinon.stub(channel, 'stopListening');
-    stopReactingStub  = sinon.stub(channel, 'stopReacting');
-    stopRespondingStub  = sinon.stub(channel, 'stopResponding');
+    this.channel = new Backbone.Radio.Channel('foobar');
 
-    returned = channel.reset();
-  });
+    this.offStub            = this.sinon.stub(this.channel, 'off');
+    this.stopListeningStub  = this.sinon.stub(this.channel, 'stopListening');
+    this.stopReactingStub   = this.sinon.stub(this.channel, 'stopReacting');
+    this.stopRespondingStub = this.sinon.stub(this.channel, 'stopResponding');
 
-  afterEach(function() {
-    offStub.restore();
-    stopListeningStub.restore();
-    stopReactingStub.restore();
-    stopRespondingStub.restore();
-    channel.reset();
+    this.returned = this.channel.reset();
   });
 
   it('should call the reset functions of Backbone.Events', function() {
-    expect(offStub).to.have.been.calledOnce;
-    expect(stopListeningStub).to.have.been.calledOnce;
+    expect(this.offStub).to.have.been.calledOnce;
+    expect(this.stopListeningStub).to.have.been.calledOnce;
   });
 
   it('should call the reset functions of Backbone.Radio.Commands', function() {
-    expect(stopReactingStub).to.have.been.calledOnce;
+    expect(this.stopReactingStub).to.have.been.calledOnce;
   });
 
   it('should call the reset functions of Backbone.Radio.Requests', function() {
-    expect(stopRespondingStub).to.have.been.calledOnce;
+    expect(this.stopRespondingStub).to.have.been.calledOnce;
   });
 
   it('should return the Channel', function() {
-    expect(returned).to.equal(channel);
+    expect(this.returned).to.equal(this.channel);
   });
 });
 
 describe('When passing an event hash to `connectEvents`', function() {
-  var channel, eventOne = 'one', eventTwo = 'two',
-  cbOne, cbTwo, internalEvents, eventsHash;
-
   beforeEach(function() {
-    cbOne = function() {};
-    cbTwo = function() {};
-    channel = Backbone.Radio.channel('test');
+    this.channel = Backbone.Radio.channel('foobar');
 
-    eventsHash = {};
-    eventsHash[eventTwo] = cbOne;
-    eventsHash[eventOne] = cbTwo;
+    this.eventFoo = 'foo';
+    this.eventBar = 'bar';
+    this.cbFoo = function() {};
+    this.cbBar = function() {};
+    this.eventsHash = {};
+    this.eventsHash[this.eventFoo] = this.cbFoo;
+    this.eventsHash[this.eventBar] = this.cbBar;
 
-    channel.connectEvents(eventsHash);
-
-    internalEvents = channel._events;
-  });
-
-  afterEach(function() {
-    channel.reset();
+    this.channel.connectEvents(this.eventsHash);
+    this.internalEvents = this.channel._events;
   });
 
   it('should attach the listeners to the Channel', function() {
-    expect(internalEvents).to.have.keys(eventTwo, eventOne);
+    expect(this.internalEvents).to.have.keys(this.eventFoo, this.eventBar);
   });
 });
 
 describe('When passing a commands hash to `connectCommands`', function() {
-  var channel, commandOne = 'one', commandTwo = 'two',
-  cbOne, cbTwo, internalCommands, commandsHash, returned;
-
   beforeEach(function() {
-    cbOne = function() {};
-    cbTwo = function() {};
-    channel = Backbone.Radio.channel('test');
+    this.channel = Backbone.Radio.channel('foobar');
 
-    commandsHash = {};
-    commandsHash[commandTwo] = cbOne;
-    commandsHash[commandOne] = cbTwo;
+    this.commandFoo = 'foo';
+    this.commandBar = 'bar';
+    this.cbFoo = function() {};
+    this.cbBar = function() {};
+    this.commandsHash = {};
+    this.commandsHash[this.commandFoo] = this.cbFoo;
+    this.commandsHash[this.commandBar] = this.cbBar;
 
-    channel.connectCommands(commandsHash);
-
-    internalCommands = channel._commands;
-  });
-
-  afterEach(function() {
-    channel.reset();
+    this.channel.connectCommands(this.commandsHash);
+    this.internalCommands = this.channel._commands;
   });
 
   it('should attach the listeners to the Channel', function() {
-    expect(internalCommands).to.have.keys(commandTwo, commandOne);
+    expect(this.internalCommands).to.have.keys(this.commandFoo, this.commandBar);
   });
 });
 
 describe('When passing a requests hash to `connectRequests`', function() {
-  var channel, requestOne = 'one', requestTwo = 'two',
-  cbOne, cbTwo, internalRequests, requestsHash, returned;
-
   beforeEach(function() {
-    cbOne = function() {};
-    cbTwo = function() {};
-    channel = Backbone.Radio.channel('test');
+    this.channel = Backbone.Radio.channel('foobar');
 
-    requestsHash = {};
-    requestsHash[requestTwo] = cbOne;
-    requestsHash[requestOne] = cbTwo;
+    this.requestFoo = 'foo';
+    this.requestBar = 'bar';
+    this.cbFoo = function() {};
+    this.cbBar = function() {};
+    this.requestsHash = {};
+    this.requestsHash[this.requestFoo] = this.cbFoo;
+    this.requestsHash[this.requestBar] = this.cbBar;
 
-    channel.connectRequests(requestsHash);
-
-    internalRequests = channel._requests;
-  });
-
-  afterEach(function() {
-    channel.reset();
+    this.channel.connectRequests(this.requestsHash);
+    this.internalRequests = this.channel._requests;
   });
 
   it('should attach the listeners to the Channel', function() {
-    expect(internalRequests).to.have.keys(requestTwo, requestOne);
+    expect(this.internalRequests).to.have.keys(this.requestFoo, this.requestBar);
   });
 });

--- a/test/spec/commands.js
+++ b/test/spec/commands.js
@@ -1,42 +1,35 @@
 describe('When commanding an action that has no handler', function() {
-  var obj = {}, returned;
-
   beforeEach(function() {
-    _.extend(obj, Backbone.Radio.Commands);
-    returned = obj.command('null');
+    this.obj = _.extend({}, Backbone.Radio.Commands);
+    this.returned = this.obj.command('handlerDoesNotExist');
   });
 
   it('should not return anything.', function() {
-    expect(returned).to.be.undefined;
+    expect(this.returned).to.be.undefined;
   });
 });
 
 describe('When commanding an action that has a handler', function() {
-  var obj = {}, returned, callbackSpy, actionName = 'test';
-
   beforeEach(function() {
-    callbackSpy = sinon.spy();
+    this.actionName = 'foo';
+    this.passedArgument = 'bar';
+    this.obj = _.extend({}, Backbone.Radio.Commands);
 
-    _.extend(obj, Backbone.Radio.Commands);
-    obj.react(actionName, callbackSpy);
+    this.callbackSpy = this.sinon.spy();
 
-    returned = obj.command(actionName, true, 'asdf');
-  });
-
-  afterEach(function() {
-    callbackSpy.reset();
-    obj.stopReacting();
+    this.obj.react(this.actionName, this.callbackSpy);
+    this.returned = this.obj.command(this.actionName, true, this.passedArgument);
   });
 
   it('should execute the handler.', function() {
-    expect(callbackSpy).to.have.been.calledOnce;
+    expect(this.callbackSpy).to.have.been.calledOnce;
   });
 
   it('should pass along the arguments to the handler.', function() {
-    expect(callbackSpy).to.have.always.been.calledWithExactly(true, 'asdf');
+    expect(this.callbackSpy).to.have.always.been.calledWithExactly(true, this.passedArgument);
   });
 
   it('should not return anything.', function() {
-    expect(returned).to.be.undefined;
+    expect(this.returned).to.be.undefined;
   });
 });

--- a/test/spec/debug.js
+++ b/test/spec/debug.js
@@ -1,171 +1,135 @@
 describe('When in DEBUG mode and firing a command on a channel without a handler', function() {
-  var consoleSpy,
-  channelName = 'global',
-  globalChannel,
-  commandName = 'some:command';
-
   beforeEach(function() {
-    Backbone.Radio.DEBUG = true;
-    globalChannel = Backbone.Radio.channel(channelName);
-    consoleSpy = sinon.stub(console, 'warn');
-    globalChannel.command(commandName);
-  });
+    this.channelName = 'foobar';
+    this.commandName = 'foo:command';
+    this.channel = Backbone.Radio.channel(this.channelName);
 
-  afterEach(function() {
-    Backbone.Radio.DEBUG = false;
-    consoleSpy.restore();
+    this.consoleSpy = this.sinon.stub(console, 'warn');
+
+    Backbone.Radio.DEBUG = true;
+    this.channel.command(this.commandName);
   });
 
   it('should throw a console warning, including the channel', function() {
-    var warning = 'An unhandled event was fired on the ' + channelName + ' channel: "' + commandName + '"';
-    expect(consoleSpy).to.have.been.calledOnce;
-    expect(consoleSpy).to.have.been.calledWithExactly(warning);
+    var warning = 'An unhandled event was fired on the ' + this.channelName + ' channel: "' + this.commandName + '"';
+    expect(this.consoleSpy).to.have.been.calledOnce;
+    expect(this.consoleSpy).to.have.been.calledWithExactly(warning);
   });
 });
 
 describe('When not in DEBUG mode and firing a command on a channel without a handler', function() {
-  var consoleSpy,
-  channelName = 'global',
-  globalChannel,
-  commandName = 'some:command';
-
   beforeEach(function() {
-    globalChannel = Backbone.Radio.channel(channelName);
-    consoleSpy = sinon.stub(console, 'warn');
-    globalChannel.command(commandName);
-  });
+    this.channelName = 'foobar';
+    this.commandName = 'foo:command';
+    this.channel = Backbone.Radio.channel(this.channelName);
 
-  afterEach(function() {
-    consoleSpy.restore();
+    this.consoleSpy = this.sinon.stub(console, 'warn');
+
+    this.channel.command(this.commandName);
   });
 
   it('should not throw a console warning', function() {
-    expect(consoleSpy).to.not.have.been.called;
+    expect(this.consoleSpy).to.not.have.been.called;
   });
 });
 
 describe('When in DEBUG mode and firing a request on a channel without a handler', function() {
-  var consoleSpy,
-  channelName = 'global',
-  globalChannel,
-  requestName = 'some:request';
-
   beforeEach(function() {
-    Backbone.Radio.DEBUG = true;
-    globalChannel = Backbone.Radio.channel(channelName);
-    consoleSpy = sinon.stub(console, 'warn');
-    globalChannel.request(requestName);
-  });
+    this.channelName = 'foobar';
+    this.commandName = 'foo:command';
+    this.channel = Backbone.Radio.channel(this.channelName);
 
-  afterEach(function() {
-    Backbone.Radio.DEBUG = false;
-    consoleSpy.restore();
+    this.consoleSpy = this.sinon.stub(console, 'warn');
+
+    Backbone.Radio.DEBUG = true;
+    this.channel.request(this.requestName);
   });
 
   it('should throw a console warning, including the channel', function() {
-    var warning = 'An unhandled event was fired on the ' + channelName + ' channel: "' + requestName + '"';
-    expect(consoleSpy).to.have.been.calledOnce;
-    expect(consoleSpy).to.have.been.calledWithExactly(warning);
+    var warning = 'An unhandled event was fired on the ' + this.channelName + ' channel: "' + this.requestName + '"';
+    expect(this.consoleSpy).to.have.been.calledOnce;
+    expect(this.consoleSpy).to.have.been.calledWithExactly(warning);
   });
 });
 
 describe('When not in DEBUG mode and firing a request on a channel without a handler', function() {
-  var consoleSpy,
-  channelName = 'global',
-  globalChannel,
-  requestName = 'some:request';
-
   beforeEach(function() {
-    globalChannel = Backbone.Radio.channel(channelName);
-    consoleSpy = sinon.stub(console, 'warn');
-    globalChannel.request(requestName);
-  });
+    this.channelName = 'foobar';
+    this.commandName = 'foo:command';
+    this.channel = Backbone.Radio.channel(this.channelName);
 
-  afterEach(function() {
-    consoleSpy.restore();
+    this.consoleSpy = this.sinon.stub(console, 'warn');
+
+    this.channel.request(this.requestName);
   });
 
   it('should not throw a console warning', function() {
-    expect(consoleSpy).to.not.have.been.called;
+    expect(this.consoleSpy).to.not.have.been.called;
   });
 });
 
 describe('When in DEBUG mode and firing a command on an object without a handler', function() {
-  var consoleSpy, obj, commandName = 'some:command';
-
   beforeEach(function() {
-    obj = _.extend({}, Backbone.Radio.Commands);
-    Backbone.Radio.DEBUG = true;
-    consoleSpy = sinon.stub(console, 'warn');
-    obj.command(commandName);
-  });
+    this.commandName = 'foo:command';
+    this.obj = _.extend({}, Backbone.Radio.Commands);
 
-  afterEach(function() {
-    Backbone.Radio.DEBUG = false;
-    consoleSpy.restore();
+    this.consoleSpy = this.sinon.stub(console, 'warn');
+
+    Backbone.Radio.DEBUG = true;
+    this.obj.command(this.commandName);
   });
 
   it('should throw a console warning', function() {
-    var warning = 'An unhandled event was fired: "' + commandName + '"';
-    expect(consoleSpy).to.have.been.calledOnce;
-    expect(consoleSpy).to.have.been.calledWithExactly(warning);
+    var warning = 'An unhandled event was fired: "' + this.commandName + '"';
+    expect(this.consoleSpy).to.have.been.calledOnce;
+    expect(this.consoleSpy).to.have.been.calledWithExactly(warning);
   });
 });
 
 describe('When not in DEBUG mode and firing a command on an object without a handler', function() {
-  var consoleSpy, obj, commandName = 'some:command';
-
   beforeEach(function() {
-    obj = _.extend({}, Backbone.Radio.Commands);
-    consoleSpy = sinon.stub(console, 'warn');
-    obj.command(commandName);
-  });
+    this.commandName = 'foo:command';
+    this.obj = _.extend({}, Backbone.Radio.Commands);
 
-  afterEach(function() {
-    consoleSpy.restore();
+    this.consoleSpy = this.sinon.stub(console, 'warn');
+
+    this.obj.command(this.commandName);
   });
 
   it('should not throw a console warning', function() {
-    expect(consoleSpy).to.not.have.been.called;
+    expect(this.consoleSpy).to.not.have.been.called;
   });
 });
 
 describe('When in DEBUG mode and firing a request on an object without a handler', function() {
-  var consoleSpy, obj, requestName = 'some:request';
-
   beforeEach(function() {
-    obj = _.extend({}, Backbone.Radio.Requests);
-    Backbone.Radio.DEBUG = true;
-    consoleSpy = sinon.stub(console, 'warn');
-    obj.request(requestName);
-  });
+    this.requestName = 'foo:request';
+    this.obj = _.extend({}, Backbone.Radio.Requests);
 
-  afterEach(function() {
-    Backbone.Radio.DEBUG = false;
-    consoleSpy.restore();
+    this.consoleSpy = this.sinon.stub(console, 'warn');
+
+    Backbone.Radio.DEBUG = true;
+    this.obj.request(this.requestName);
   });
 
   it('should throw a console warning', function() {
-    var warning = 'An unhandled event was fired: "' + requestName + '"';
-    expect(consoleSpy).to.have.been.calledOnce;
-    expect(consoleSpy).to.have.been.calledWithExactly(warning);
+    var warning = 'An unhandled event was fired: "' + this.requestName + '"';
+    expect(this.consoleSpy).to.have.been.calledOnce;
+    expect(this.consoleSpy).to.have.been.calledWithExactly(warning);
   });
 });
 
 describe('When not in DEBUG mode and firing a command on an object without a handler', function() {
-  var consoleSpy, obj, requestName = 'some:request';
-
   beforeEach(function() {
-    obj = _.extend({}, Backbone.Radio.Requests);
-    consoleSpy = sinon.stub(console, 'warn');
-    obj.request(requestName);
-  });
+    this.requestName = 'foo:request';
+    this.obj = _.extend({}, Backbone.Radio.Requests);
 
-  afterEach(function() {
-    consoleSpy.restore();
+    this.consoleSpy = this.sinon.stub(console, 'warn');
+
+    this.obj.request(this.requestName);
   });
 
   it('should not throw a console warning', function() {
-    expect(consoleSpy).to.not.have.been.called;
+    expect(this.consoleSpy).to.not.have.been.called;
   });
 });

--- a/test/spec/radio.js
+++ b/test/spec/radio.js
@@ -1,24 +1,20 @@
 describe('Calling channel on a nonexistent channel', function() {
-  var channel;
-
   beforeEach(function() {
-    channel = Backbone.Radio.channel('global');
+    this.channel = Backbone.Radio.channel('foobar');
   });
 
   it('should create a new instance of the Channel', function() {
-    expect(channel).to.be.instanceOf(Backbone.Radio.Channel);
+    expect(this.channel).to.be.instanceOf(Backbone.Radio.Channel);
   });
 });
 
 describe('Calling channel twice with the same name', function() {
-  var channelOne, channelTwo;
-
   beforeEach(function() {
-    channelOne = Backbone.Radio.channel('global');
-    channelTwo = Backbone.Radio.channel('global');
+    this.channelOne = Backbone.Radio.channel('foobar');
+    this.channelTwo = Backbone.Radio.channel('foobar');
   });
 
   it('should return the same channel', function() {
-    expect(channelOne).to.equal(channelTwo);
+    expect(this.channelOne).to.equal(this.channelTwo);
   });
 });

--- a/test/spec/requests.js
+++ b/test/spec/requests.js
@@ -1,60 +1,51 @@
 describe('When making a request that has no handler', function() {
-  var obj = {}, returned;
-
   beforeEach(function() {
-    _.extend(obj, Backbone.Radio.Requests);
-    returned = obj.request('null');
+    this.obj = _.extend({}, Backbone.Radio.Requests);
+    this.returned = this.obj.request('foobar');
   });
 
   it('should not return anything.', function() {
-    expect(returned).to.be.undefined;
+    expect(this.returned).to.be.undefined;
   });
 });
 
 describe('When making a request that has a handler', function() {
-  var obj = {}, returned, callback, callbackSpy, actionName = 'test';
-
   beforeEach(function() {
-    callback = function() {
-      return 'request complete';
-    };
-    callbackSpy = sinon.spy(callback);
+    this.actionName = 'foo';
+    this.passedArgument = 'foobar';
+    this.obj = _.extend({}, Backbone.Radio.Requests);
 
-    _.extend(obj, Backbone.Radio.Requests);
-    obj.respond(actionName, callbackSpy);
+    this.callback = function() { return 'request complete'; };
+    this.callbackSpy = this.sinon.spy(this.callback);
 
-    returned = obj.request(actionName, true, 'asdf');
-  });
-
-  afterEach(function() {
-    callbackSpy.reset();
-    obj.stopResponding();
+    this.obj.respond(this.actionName, this.callbackSpy);
+    this.returned = this.obj.request(this.actionName, true, this.passedArgument);
   });
 
   it('should execute the handler.', function() {
-    expect(callbackSpy).to.have.been.calledOnce;
+    expect(this.callbackSpy).to.have.been.calledOnce;
   });
 
   it('should pass along the arguments to the handler.', function() {
-    expect(callbackSpy).to.have.always.been.calledWithExactly(true, 'asdf');
+    expect(this.callbackSpy).to.have.always.been.calledWithExactly(true, this.passedArgument);
   });
 
   it('should return the value of the handler.', function() {
-    expect(returned).to.equal('request complete');
+    expect(this.returned).to.equal('request complete');
   });
 });
 
 describe('When making a request that has a flat value as a handler', function() {
-  var obj = {}, returned, actionName = 'test';
-
   beforeEach(function() {
-    _.extend(obj, Backbone.Radio.Requests);
-    obj.respond(actionName, 'hello');
+    this.actionName = 'foo';
+    this.response = 'foobar';
+    this.obj = _.extend({}, Backbone.Radio.Requests);
 
-    returned = obj.request(actionName);
+    this.obj.respond(this.actionName, this.response);
+    this.returned = this.obj.request(this.actionName);
   });
 
   it('should return that value.', function() {
-    expect(returned).to.equal('hello');
+    expect(this.returned).to.equal(this.response);
   });
 });

--- a/test/spec/top-level.js
+++ b/test/spec/top-level.js
@@ -1,138 +1,107 @@
 describe('When executing Commands methods from the top-level API', function() {
-  var channel, channelName = 'global', actionName = 'some:action',
-  reactStub, reactOnceStub, stopReactingStub, commandStub;
-
   beforeEach(function() {
-    channel = Backbone.Radio.channel(channelName);
+    this.channelName = 'foobar';
+    this.actionName = 'foo:request';
+    this.channel = Backbone.Radio.channel(this.channelName);
 
-    reactStub = sinon.stub(channel, 'react');
-    reactOnceStub = sinon.stub(channel, 'reactOnce');
-    stopReactingStub = sinon.stub(channel, 'stopReacting');
-    commandStub = sinon.stub(channel, 'command');
+    this.reactStub        = this.sinon.stub(this.channel, 'react');
+    this.reactOnceStub    = this.sinon.stub(this.channel, 'reactOnce');
+    this.stopReactingStub = this.sinon.stub(this.channel, 'stopReacting');
+    this.commandStub      = this.sinon.stub(this.channel, 'command');
 
-    Backbone.Radio.react(channelName, actionName, true, '1234');
-    Backbone.Radio.reactOnce(channelName, actionName, false, '4321');
-    Backbone.Radio.stopReacting(channelName, actionName, 'three', 'four');
-    Backbone.Radio.command(channelName, actionName, 'ok', 'notOk');
-  });
-
-  afterEach(function() {
-    reactStub.restore();
-    reactOnceStub.restore();
-    stopReactingStub.restore();
-    commandStub.restore();
-    channel.reset();
+    Backbone.Radio.react(this.channelName, this.actionName, 'foo1', 'bar1');
+    Backbone.Radio.reactOnce(this.channelName, this.actionName, 'foo2', 'bar2');
+    Backbone.Radio.stopReacting(this.channelName, this.actionName, 'foo3', 'bar3');
+    Backbone.Radio.command(this.channelName, this.actionName, 'foo4', 'bar4');
   });
 
   it('should execute each method on the proper channel.', function() {
-    expect(reactStub).to.have.been.calledOnce;
-    expect(reactOnceStub).to.have.been.calledOnce;
-    expect(stopReactingStub).to.have.been.calledOnce;
-    expect(commandStub).to.have.been.calledOnce;
+    expect(this.reactStub).to.have.been.calledOnce;
+    expect(this.reactOnceStub).to.have.been.calledOnce;
+    expect(this.stopReactingStub).to.have.been.calledOnce;
+    expect(this.commandStub).to.have.been.calledOnce;
   });
 
   it('should pass along the arguments.', function() {
-    expect(reactStub).to.have.always.been.calledWithExactly(true, '1234');
-    expect(reactOnceStub).to.have.always.been.calledWithExactly(false, '4321');
-    expect(stopReactingStub).to.have.always.been.calledWithExactly('three', 'four');
-    expect(commandStub).to.have.always.been.calledWithExactly('ok', 'notOk');
+    expect(this.reactStub).to.have.always.been.calledWithExactly('foo1', 'bar1');
+    expect(this.reactOnceStub).to.have.always.been.calledWithExactly('foo2', 'bar2');
+    expect(this.stopReactingStub).to.have.always.been.calledWithExactly('foo3', 'bar3');
+    expect(this.commandStub).to.have.always.been.calledWithExactly('foo4', 'bar4');
   });
 });
 
 describe('When executing Requests methods from the top-level API', function() {
-  var channel, channelName = 'global', requestName = 'some:request',
-  respondStub, respondOnceStub, stopRespondingStub, requestStub;
-
   beforeEach(function() {
-    channel = Backbone.Radio.channel(channelName);
+    this.channelName = 'foobar';
+    this.requestName = 'foo:request';
+    this.channel = Backbone.Radio.channel(this.channelName);
 
-    respondStub = sinon.stub(channel, 'respond');
-    respondOnceStub = sinon.stub(channel, 'respondOnce');
-    stopRespondingStub = sinon.stub(channel, 'stopResponding');
-    requestStub = sinon.stub(channel, 'request');
+    this.respondStub        = this.sinon.stub(this.channel, 'respond');
+    this.respondOnceStub    = this.sinon.stub(this.channel, 'respondOnce');
+    this.stopRespondingStub = this.sinon.stub(this.channel, 'stopResponding');
+    this.requestStub        = this.sinon.stub(this.channel, 'request');
 
-    Backbone.Radio.respond(channelName, requestName, true, '1234');
-    Backbone.Radio.respondOnce(channelName, requestName, false, '4321');
-    Backbone.Radio.stopResponding(channelName, requestName, 'three', 'four');
-    Backbone.Radio.request(channelName, requestName, 'ok', 'notOk');
-  });
-
-  afterEach(function() {
-    respondStub.restore();
-    respondOnceStub.restore();
-    stopRespondingStub.restore();
-    requestStub.restore();
-    channel.reset();
+    Backbone.Radio.respond(this.channelName, this.requestName, 'foo1', 'bar1');
+    Backbone.Radio.respondOnce(this.channelName, this.requestName, 'foo2', 'bar2');
+    Backbone.Radio.stopResponding(this.channelName, this.requestName, 'foo3', 'bar3');
+    Backbone.Radio.request(this.channelName, this.requestName, 'foo4', 'bar4');
   });
 
   it('should execute each method on the proper channel.', function() {
-    expect(respondStub).to.have.been.calledOnce;
-    expect(respondOnceStub).to.have.been.calledOnce;
-    expect(stopRespondingStub).to.have.been.calledOnce;
-    expect(requestStub).to.have.been.calledOnce;
+    expect(this.respondStub).to.have.been.calledOnce;
+    expect(this.respondOnceStub).to.have.been.calledOnce;
+    expect(this.stopRespondingStub).to.have.been.calledOnce;
+    expect(this.requestStub).to.have.been.calledOnce;
   });
 
   it('should pass along the arguments.', function() {
-    expect(respondStub).to.have.always.been.calledWithExactly(true, '1234');
-    expect(respondOnceStub).to.have.always.been.calledWithExactly(false, '4321');
-    expect(stopRespondingStub).to.have.always.been.calledWithExactly('three', 'four');
-    expect(requestStub).to.have.always.been.calledWithExactly('ok', 'notOk');
+    expect(this.respondStub).to.have.always.been.calledWithExactly('foo1', 'bar1');
+    expect(this.respondOnceStub).to.have.always.been.calledWithExactly('foo2', 'bar2');
+    expect(this.stopRespondingStub).to.have.always.been.calledWithExactly('foo3', 'bar3');
+    expect(this.requestStub).to.have.always.been.calledWithExactly('foo4', 'bar4');
   });
 });
 
 describe('When executing Events methods from the top-level API', function() {
-  var channel, channelName = 'global', eventName = 'some:event',
-  listenToStub, listenToOnceStub, stopListeningStub, triggerStub,
-  onStub, onceStub, offStub;
-
   beforeEach(function() {
-    channel = Backbone.Radio.channel(channelName);
+    this.channelName = 'foobar';
+    this.eventName = 'foo:event';
+    this.channel = Backbone.Radio.channel(this.channelName);
 
-    listenToStub = sinon.stub(channel, 'listenTo');
-    listenToOnceStub = sinon.stub(channel, 'listenToOnce');
-    stopListeningStub = sinon.stub(channel, 'stopListening');
-    triggerStub = sinon.stub(channel, 'trigger');
-    onStub = sinon.stub(channel, 'on');
-    onceStub = sinon.stub(channel, 'once');
-    offStub = sinon.stub(channel, 'off');
+    this.listenToStub      = this.sinon.stub(this.channel, 'listenTo');
+    this.listenToOnceStub  = this.sinon.stub(this.channel, 'listenToOnce');
+    this.stopListeningStub = this.sinon.stub(this.channel, 'stopListening');
+    this.triggerStub       = this.sinon.stub(this.channel, 'trigger');
+    this.onStub            = this.sinon.stub(this.channel, 'on');
+    this.onceStub          = this.sinon.stub(this.channel, 'once');
+    this.offStub           = this.sinon.stub(this.channel, 'off');
 
-    Backbone.Radio.listenTo(channelName, eventName, true, '1234');
-    Backbone.Radio.listenToOnce(channelName, eventName, false, '4321');
-    Backbone.Radio.stopListening(channelName, eventName, 'three', 'four');
-    Backbone.Radio.trigger(channelName, eventName, 'ok', 'notOk');
-    Backbone.Radio.on(channelName, eventName, 'test', 'testpls');
-    Backbone.Radio.once(channelName, eventName, 'food', 'isGood');
-    Backbone.Radio.off(channelName, eventName, 'sleep', 'isNice');
-  });
-
-  afterEach(function() {
-    listenToStub.restore();
-    listenToOnceStub.restore();
-    stopListeningStub.restore();
-    triggerStub.restore();
-    onStub.restore();
-    onceStub.restore();
-    offStub.restore();
-    channel.reset();
+    Backbone.Radio.listenTo(this.channelName, this.eventName, 'foo1', 'bar1');
+    Backbone.Radio.listenToOnce(this.channelName, this.eventName, 'foo2', 'bar2');
+    Backbone.Radio.stopListening(this.channelName, this.eventName, 'foo3', 'bar3');
+    Backbone.Radio.trigger(this.channelName, this.eventName, 'foo4', 'bar4');
+    Backbone.Radio.on(this.channelName, this.eventName, 'foo5', 'bar5');
+    Backbone.Radio.once(this.channelName, this.eventName, 'foo6', 'bar6');
+    Backbone.Radio.off(this.channelName, this.eventName, 'foo7', 'bar7');
   });
 
   it('should execute each method on the proper channel.', function() {
-    expect(listenToStub).to.have.been.calledOnce;
-    expect(listenToOnceStub).to.have.been.calledOnce;
-    expect(stopListeningStub).to.have.been.calledOnce;
-    expect(triggerStub).to.have.been.calledOnce;
-    expect(onStub).to.have.been.calledOnce;
-    expect(onceStub).to.have.been.calledOnce;
-    expect(offStub).to.have.been.calledOnce;
+    expect(this.listenToStub).to.have.been.calledOnce;
+    expect(this.listenToOnceStub).to.have.been.calledOnce;
+    expect(this.stopListeningStub).to.have.been.calledOnce;
+    expect(this.triggerStub).to.have.been.calledOnce;
+    expect(this.onStub).to.have.been.calledOnce;
+    expect(this.onceStub).to.have.been.calledOnce;
+    expect(this.offStub).to.have.been.calledOnce;
   });
 
   it('should pass along the arguments.', function() {
-    expect(listenToStub).to.have.always.been.calledWithExactly(true, '1234');
-    expect(listenToOnceStub).to.have.always.been.calledWithExactly(false, '4321');
-    expect(stopListeningStub).to.have.always.been.calledWithExactly('three', 'four');
-    expect(triggerStub).to.have.always.been.calledWithExactly('ok', 'notOk');
-    expect(onStub).to.have.always.been.calledWithExactly('test', 'testpls');
-    expect(onceStub).to.have.always.been.calledWithExactly('food', 'isGood');
-    expect(offStub).to.have.always.been.calledWithExactly('sleep', 'isNice');
+    expect(this.listenToStub).to.have.always.been.calledWithExactly('foo1', 'bar1');
+    expect(this.listenToOnceStub).to.have.always.been.calledWithExactly('foo2', 'bar2');
+    expect(this.stopListeningStub).to.have.always.been.calledWithExactly('foo3', 'bar3');
+    expect(this.triggerStub).to.have.always.been.calledWithExactly('foo4', 'bar4');
+    expect(this.onStub).to.have.always.been.calledWithExactly('foo5', 'bar5');
+    expect(this.onceStub).to.have.always.been.calledWithExactly('foo6', 'bar6');
+    expect(this.offStub).to.have.always.been.calledWithExactly('foo7', 'bar7');
   });
 });

--- a/test/spec/tune-in.js
+++ b/test/spec/tune-in.js
@@ -1,146 +1,121 @@
 describe('When tuned into a channel and emitting an event', function() {
-  var consoleSpy,
-  channelName = 'global',
-  globalChannel,
-  eventName = 'some:event';
-
   beforeEach(function() {
-    globalChannel = Backbone.Radio.channel(channelName);
-    Backbone.Radio.tuneIn(channelName);
-    consoleSpy = sinon.stub(console, 'log');
-    globalChannel.trigger(eventName, 'pasta', true);
+    this.channelName = 'foobar';
+    this.eventName = 'foo:event';
+    this.channel = Backbone.Radio.channel(this.channelName);
+
+    this.consoleSpy = this.sinon.stub(console, 'log');
+
+    Backbone.Radio.tuneIn(this.channelName);
+    this.channel.trigger(this.eventName, 'foo', 'bar');
   });
 
   afterEach(function() {
-    consoleSpy.restore();
-    Backbone.Radio.tuneOut(channelName);
+    Backbone.Radio.tuneOut(this.channelName);
   });
 
   it('should log that activity, with the arguments', function() {
-    var warning = '[' + channelName + '] "' + eventName + '"';
-    var args = [ 'pasta', true ];
-    expect(consoleSpy).to.have.been.calledOnce;
-    expect(consoleSpy).to.have.been.calledWithExactly(warning, args);
+    var warning = '[' + this.channelName + '] "' + this.eventName + '"';
+    var args = ['foo', 'bar'];
+    expect(this.consoleSpy).to.have.been.calledOnce;
+    expect(this.consoleSpy).to.have.been.calledWithExactly(warning, args);
   });
 });
 
 describe('When tuning in, then out, and emitting an event', function() {
-  var consoleSpy,
-  channelName = 'global',
-  globalChannel,
-  eventName = 'some:event';
-
   beforeEach(function() {
-    globalChannel = Backbone.Radio.channel(channelName);
-    Backbone.Radio.tuneIn(channelName);
-    Backbone.Radio.tuneOut(channelName);
-    consoleSpy = sinon.stub(console, 'log');
-    globalChannel.trigger(eventName);
-  });
+    this.channelName = 'foobar';
+    this.eventName = 'foo:event';
+    this.consoleSpy = this.sinon.stub(console, 'log');
+    this.channel = Backbone.Radio.channel(this.channelName);
 
-  afterEach(function() {
-    consoleSpy.restore();
+    Backbone.Radio.tuneIn(this.channelName);
+    Backbone.Radio.tuneOut(this.channelName);
+    this.channel.trigger(this.eventName);
   });
 
   it('should not log that activity', function() {
-    expect(consoleSpy).to.not.have.been.called;
+    expect(this.consoleSpy).to.not.have.been.called;
   });
 });
 
 describe('When tuned into a channel and making a request', function() {
-  var consoleSpy,
-  channelName = 'global',
-  globalChannel,
-  requestName = 'some:request';
-
   beforeEach(function() {
-    globalChannel = Backbone.Radio.channel(channelName);
-    Backbone.Radio.tuneIn(channelName);
-    consoleSpy = sinon.stub(console, 'log');
-    globalChannel.request(requestName, 'sandwiches', 123);
+    this.channelName = 'foobar';
+    this.eventName = 'foo:request';
+    this.channel = Backbone.Radio.channel(this.channelName);
+
+    this.consoleSpy = this.sinon.stub(console, 'log');
+
+    Backbone.Radio.tuneIn(this.channelName);
+    this.channel.request(this.requestName, 'foo', 'bar');
   });
 
   afterEach(function() {
-    consoleSpy.restore();
-    Backbone.Radio.tuneOut(channelName);
+    Backbone.Radio.tuneOut(this.channelName);
   });
 
   it('should log that activity', function() {
-    var warning = '[' + channelName + '] "' + requestName + '"';
-    var args = [ 'sandwiches', 123 ];
-    expect(consoleSpy).to.have.been.calledOnce;
-    expect(consoleSpy).to.have.been.calledWithExactly(warning, args);
+    var warning = '[' + this.channelName + '] "' + this.requestName + '"';
+    var args = ['foo', 'bar'];
+    expect(this.consoleSpy).to.have.been.calledOnce;
+    expect(this.consoleSpy).to.have.been.calledWithExactly(warning, args);
   });
 });
 
 describe('When tuning in, then out, and making a request', function() {
-  var consoleSpy,
-  channelName = 'global',
-  globalChannel,
-  requestName = 'some:request';
-
   beforeEach(function() {
-    globalChannel = Backbone.Radio.channel(channelName);
-    Backbone.Radio.tuneIn(channelName);
-    Backbone.Radio.tuneOut(channelName);
-    consoleSpy = sinon.stub(console, 'log');
-    globalChannel.request(requestName);
-  });
+    this.channelName = 'foobar';
+    this.eventName = 'foo:request';
+    this.consoleSpy = this.sinon.stub(console, 'log');
+    this.channel = Backbone.Radio.channel(this.channelName);
 
-  afterEach(function() {
-    consoleSpy.restore();
+    Backbone.Radio.tuneIn(this.channelName);
+    Backbone.Radio.tuneOut(this.channelName);
+    this.channel.request(this.requestName);
   });
 
   it('should not log that activity', function() {
-    expect(consoleSpy).to.not.have.been.called;
+    expect(this.consoleSpy).to.not.have.been.called;
   });
 });
 
 describe('When tuned into a channel and ordering a command', function() {
-  var consoleSpy,
-  channelName = 'global',
-  globalChannel,
-  commandName = 'some:command';
-
   beforeEach(function() {
-    globalChannel = Backbone.Radio.channel(channelName);
-    Backbone.Radio.tuneIn(channelName);
-    consoleSpy = sinon.stub(console, 'log');
-    globalChannel.command(commandName, 'pizza', 'alfredo');
+    this.channelName = 'foobar';
+    this.eventName = 'foo:command';
+    this.consoleSpy = this.sinon.stub(console, 'log');
+    this.channel = Backbone.Radio.channel(this.channelName);
+
+    Backbone.Radio.tuneIn(this.channelName);
+    this.channel.command(this.commandName, 'foo', 'bar');
   });
 
   afterEach(function() {
-    consoleSpy.restore();
-    Backbone.Radio.tuneOut(channelName);
+    Backbone.Radio.tuneOut(this.channelName);
   });
 
   it('should log that activity', function() {
-    var warning = '[' + channelName + '] "' + commandName + '"';
-    var args = [ 'pizza', 'alfredo' ];
-    expect(consoleSpy).to.have.been.calledOnce;
-    expect(consoleSpy).to.have.been.calledWithExactly(warning, args);
+    var warning = '[' + this.channelName + '] "' + this.commandName + '"';
+    var args = ['foo', 'bar'];
+    expect(this.consoleSpy).to.have.been.calledOnce;
+    expect(this.consoleSpy).to.have.been.calledWithExactly(warning, args);
   });
 });
 
 describe('When tuning in, then out, and ordering a command', function() {
-  var consoleSpy,
-  channelName = 'global',
-  globalChannel,
-  commandName = 'some:command';
-
   beforeEach(function() {
-    globalChannel = Backbone.Radio.channel(channelName);
-    Backbone.Radio.tuneIn(channelName);
-    Backbone.Radio.tuneOut(channelName);
-    consoleSpy = sinon.stub(console, 'log');
-    globalChannel.command(commandName);
-  });
+    this.channelName = 'foobar';
+    this.eventName = 'foo:command';
+    this.consoleSpy = this.sinon.stub(console, 'log');
+    this.channel = Backbone.Radio.channel(this.channelName);
 
-  afterEach(function() {
-    consoleSpy.restore();
+    Backbone.Radio.tuneIn(this.channelName);
+    Backbone.Radio.tuneOut(this.channelName);
+    this.channel.command(this.commandName);
   });
 
   it('should not log that activity', function() {
-    expect(consoleSpy).to.not.have.been.called;
+    expect(this.consoleSpy).to.not.have.been.called;
   });
 });


### PR DESCRIPTION
Refactors tests to use instance variables on `this` instead of variables at a higher scope. This causes a lot of things to be cleaned up automatically and makes tests more readable and self-contained.

**Changes**
- Refactored all tests to use `this` instead of variables
- Reordered some stuff within `beforeEach` blocks (values/setup - line break - do stuff)
