### PR TITLE
Fix style consistency errors, minify code better

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -31,7 +31,7 @@
   "eqnull"        : false,
   "esnext"        : false,
   "evil"          : false,
-  "expr"          : false,
+  "expr"          : true,
   "funcscope"     : false,
   "globalstrict"  : false,
   "iterator"      : false,
@@ -74,6 +74,7 @@
     "require": true,
     "module": true,
     "define": true,
-    "exports": true
+    "exports": true,
+    "slice": true
   }
 }

--- a/src/channel.js
+++ b/src/channel.js
@@ -2,7 +2,7 @@
  * Backbone.Radio.Channel
  * ----------------------
  * A Channel is an object that extends from Backbone.Events,
- * Radio.Commands, and Radio.Requests. 
+ * Radio.Commands, and Radio.Requests.
  *
  */
 
@@ -24,10 +24,9 @@ _.extend(Radio.Channel.prototype, {
 });
 
 function _connect(methodName, hash, context) {
-  if ( !hash ) { return; }
-  context = context || this;
+  if (!hash) { return; }
   _.each(hash, function(fn, eventName) {
-    this[methodName](eventName, _.bind(fn, context));
+    this[methodName](eventName, _.bind(fn, context || this));
   }, this);
 }
 
@@ -38,6 +37,5 @@ var map = {
 };
 
 _.each(map, function(methodName, systemName) {
-  var connectName = 'connect'+ systemName;
-  Radio.Channel.prototype[connectName] = _.partial(_connect, methodName);
+  Radio.Channel.prototype['connect' + systemName] = _.partial(_connect, methodName);
 });

--- a/src/commands.js
+++ b/src/commands.js
@@ -7,8 +7,8 @@
 
 Radio.Commands = {
   command: function(name) {
-    var args = Array.prototype.slice.call(arguments, 1);
-    var isChannel = this._channelName ? true : false;
+    var args = slice.call(arguments, 1);
+    var isChannel = !!this._channelName;
 
     // Check if we should log the request, and if so, do it
     if (isChannel && this._tunedIn) {
@@ -25,21 +25,15 @@ Radio.Commands = {
     }
 
     var handler = this._commands[name];
-    var cb = handler.callback;
-    var context = handler.context;
-    cb.apply(context, args);
+    handler.callback.apply(handler.context, args);
   },
 
   react: function(name, callback, context) {
-    if (!this._commands) {
-      this._commands = {};
-    }
-
-    context = context || this;
+    this._commands || (this._commands = {});
 
     this._commands[name] = {
       callback: callback,
-      context: context
+      context: context || this
     };
 
     return this;

--- a/src/proxy.js
+++ b/src/proxy.js
@@ -10,7 +10,7 @@
  _.each(systems, function(system) {
   _.each(system, function(method, methodName) {
     Radio[methodName] = function(channelName) {
-      args = Array.prototype.slice.call(arguments, 2);
+      args = slice.call(arguments, 2);
       channel = this.channel(channelName);
       return channel[methodName].apply(this, args);
     };

--- a/src/radio.js
+++ b/src/radio.js
@@ -14,12 +14,12 @@ _.extend(Radio, {
     if (!channelName) {
       throw new Error('You must provide a name for the channel.');
     }
-    return Radio._getChannel( channelName );
+    return Radio._getChannel(channelName);
   },
 
   _getChannel: function(channelName) {
     var channel = Radio._channels[channelName];
-    if(!channel) {
+    if (!channel) {
       channel = new Radio.Channel(channelName);
       Radio._channels[channelName] = channel;
     }

--- a/src/tune-in.js
+++ b/src/tune-in.js
@@ -6,22 +6,22 @@
  */
 
 // Log information about the channel and event
-var _log = function(channelName, eventName) {
-  var args = Array.prototype.slice.call(arguments, 2);
-  console.log('[' + channelName + '] "'+eventName+'"', args);
-};
+function _log(channelName, eventName) {
+  var args = slice.call(arguments, 2);
+  console.log('[' + channelName + '] "' + eventName + '"', args);
+}
 
 var _logs = {};
 
 // This is to produce an identical function in both tuneIn and tuneOut,
 // so that Backbone.Events unregisters it.
-var _partial = function(channelName) {
+function _partial(channelName) {
   return _logs[channelName] || (_logs[channelName] = _.partial(_log, channelName));
-};
+}
 
 _.extend(Radio, {
 
-  // Logs all events on this channel to the console. It sets an 
+  // Logs all events on this channel to the console. It sets an
   // internal value on the channel telling it we're listening,
   // then sets a listener on the Backbone.Events
   tuneIn: function(channelName) {

--- a/src/wrapper.js
+++ b/src/wrapper.js
@@ -26,6 +26,8 @@
     return this;
   };
 
+  var slice = Array.prototype.slice;
+
   // @include radio.js
   // @include tune-in.js
   // @include commands.js


### PR DESCRIPTION
Gets rid of useless variables and makes basic code structure changes for better minifying. Also fixes some whitespace stuff.

**Changes:**
- Create `Array.prototype.slice` reference
  - `var args = Array.prototype.slice.call(arguments, 2);`
  - `var args = slice.call(arguments, 2);`
- Replace callback/constants creation with function
  - `_.isFunction(callback) ? callback : _.constant(callback);`
  - `makeCallback(callback);`
- Removes variables that are only used once
  - `var cb = handler.callback, context = handler.context; cb.apply(handler.context, args)`
  - `handler.callback.apply(handler.context, args)`
- use expressions instead of if statement blocks
  - `if (!this._requests) { this._requests = {}; }`
  - `this._requests || (this._requests = {});`
- use named functions instead of variables
  - `var name = function() { ... }`
  - `function name() { ... }`
- use shorthands
  - `var isChannel = this._channelName ? true : false;`
  - `var isChannel = !!this._channelName;`
- Fixes misc whitespace weirdness
