### PR TITLE
Adds debug functionality to stop listening methods.

### DIFF
--- a/src/commands.js
+++ b/src/commands.js
@@ -49,11 +49,17 @@ Radio.Commands = {
   },
 
   stopReacting: function(name) {
-    if (!this._commands) { return; }
+    var store = this._commands;
     if (!name) {
       delete this._commands;
-    } else {
-      delete this._commands[name];
+    }
+    else if (store && store[name]) {
+      delete store[name];
+    }
+    else if (Radio.DEBUG) {
+      var channelName = this._channelName;
+      var channelText = channelName ? ' on the ' + channelName + ' channel.' : '';
+      console.warn('Attempted to remove the unregistered command "' + name + '"' + channelText);
     }
   }
 };

--- a/src/requests.js
+++ b/src/requests.js
@@ -52,11 +52,17 @@ Radio.Requests = {
   },
 
   stopResponding: function(name) {
-    if (!this._requests) { return; }
+    var store = this._requests;
     if (!name) {
       delete this._requests;
-    } else {
-      delete this._requests[name];
+    }
+    else if (store && store[name]) {
+      delete store[name];
+    }
+    else if (Radio.DEBUG) {
+      var channelName = this._channelName;
+      var channelText = channelName ? ' on the ' + channelName + ' channel.' : '';
+      console.warn('Attempted to remove the unregistered request "' + name + '"' + channelText);
     }
   }
 };

--- a/test/.jshintrc
+++ b/test/.jshintrc
@@ -21,7 +21,7 @@
   "maxparams"     : 4,
   "maxdepth"      : 2,
   "maxcomplexity" : 10,
-  "maxlen"        : 120,
+  "maxlen"        : 150,
 
   "asi"           : false,
   "boss"          : false,

--- a/test/spec/debug.js
+++ b/test/spec/debug.js
@@ -38,6 +38,30 @@ describe('DEBUG mode:', function() {
       this.warning = 'An unhandled event was fired: "' + this.eventName + '"';
       expect(this.consoleStub).to.have.been.calledOnce.and.calledWithExactly(this.warning);
     });
+
+    it('should log a console warning when unregistering a command that was never registered on a channel', function() {
+      this.channel.stopReacting(this.eventName);
+      var warning = 'Attempted to remove the unregistered command "' + this.eventName + '" on the foo channel.';
+      expect(this.consoleStub).to.have.been.calledOnce.and.calledWithExactly(warning);
+    });
+
+    it('should log a console warning when unregistering a request that was never registered on a channel', function() {
+      this.channel.stopResponding(this.eventName);
+      var warning = 'Attempted to remove the unregistered request "' + this.eventName + '" on the foo channel.';
+      expect(this.consoleStub).to.have.been.calledOnce.and.calledWithExactly(warning);
+    });
+
+    it('should log a console warning when unregistering a command that was never registered on an object', function() {
+      this.Commands.stopReacting(this.eventName);
+      var warning = 'Attempted to remove the unregistered command "' + this.eventName + '"';
+      expect(this.consoleStub).to.have.been.calledOnce.and.calledWithExactly(warning);
+    });
+
+    it('should log a console warning when unregistering a request that was never registered on an object', function() {
+      this.Requests.stopResponding(this.eventName);
+      var warning = 'Attempted to remove the unregistered request "' + this.eventName + '"';
+      expect(this.consoleStub).to.have.been.calledOnce.and.calledWithExactly(warning);
+    });
   });
 
   describe('when turned off', function() {
@@ -58,6 +82,26 @@ describe('DEBUG mode:', function() {
 
     it('should not log a console warning when firing a request on an object without a handler', function() {
       this.Requests.request(this.eventName);
+      expect(this.consoleStub).to.not.have.been.called;
+    });
+
+    it('should not log a console warning when unregistering a command that was never registered on a channel', function() {
+      this.channel.stopReacting(this.eventName);
+      expect(this.consoleStub).to.not.have.been.called;
+    });
+
+    it('should not log a console warning when unregistering a request that was never registered on a channel', function() {
+      this.channel.stopResponding(this.eventName);
+      expect(this.consoleStub).to.not.have.been.called;
+    });
+
+    it('should not log a console warning when unregistering a command that was never registered on an object', function() {
+      this.Commands.stopReacting(this.eventName);
+      expect(this.consoleStub).to.not.have.been.called;
+    });
+
+    it('should not log a console warning when unregistering a request that was never registered on an object', function() {
+      this.Requests.stopResponding(this.eventName);
       expect(this.consoleStub).to.not.have.been.called;
     });
   });


### PR DESCRIPTION
Resolves #33

This adds DEBUG functionality to the stop listening methods. This makes it so `trigger` and `stopListening` both give warnings when you call them with an unregistered event.
