### PR TITLE
Unbind methods

### DIFF
--- a/src/channel.js
+++ b/src/channel.js
@@ -36,8 +36,9 @@ _.extend(Radio.Channel.prototype, {
 
   _connect: function(methodName, hash, context) {
     if (!hash) { return; }
+
     _.each(hash, function(fn, eventName) {
-      this[methodName](eventName, _.bind(fn, context || this));
+      this[methodName](eventName, fn, context || this);
     }, this);
     return this;
   }


### PR DESCRIPTION
Storing the callbacks directly lets us inspect the functions later. This is awesome for seeing what Radio callbacks will do!

``` js
Radio._channels.milestone.reqres._wreqrHandlers['is-empty'].callback 

//=>
function () {
      var args = slice.call(arguments);
      args.unshift(this.models);
      return _[method].apply(_, args);
    } 
```
