### PR TITLE
Tests individual files.

### DIFF
--- a/src/radio.js
+++ b/src/radio.js
@@ -5,6 +5,17 @@
  *
  */
 
+var previousRadio = Backbone.Radio;
+
+var Radio = Backbone.Radio = {};
+
+Radio.VERSION = '<%= version %>';
+
+Radio.noConflict = function () {
+  Backbone.Radio = previousRadio;
+  return this;
+};
+
 _.extend(Radio, {
   _channels: {},
 

--- a/src/wrapper.js
+++ b/src/wrapper.js
@@ -15,17 +15,6 @@
 }(this, function(Backbone, _) {
   'use strict';
 
-  var previousRadio = Backbone.Radio;
-
-  var Radio = Backbone.Radio = {};
-
-  Radio.VERSION = '<%= version %>';
-
-  Radio.noConflict = function () {
-    Backbone.Radio = previousRadio;
-    return this;
-  };
-
   var slice = Array.prototype.slice;
 
   // @include radio.js

--- a/test/spec-runner.html
+++ b/test/spec-runner.html
@@ -17,7 +17,12 @@
   <script src='../bower_components/backbone/backbone.js'></script>
 
   <!-- Load the library -->
-  <script src='../.tmp/backbone.radio.js'></script>
+  <script src='../src/radio.js'></script>
+  <script src='../src/tune-in.js'></script>
+  <script src='../src/commands.js'></script>
+  <script src='../src/requests.js'></script>
+  <script src='../src/channel.js'></script>
+  <script src='../src/proxy.js'></script>
 
   <!-- Setup tests -->
   <script src='setup/helpers.js'></script>


### PR DESCRIPTION
Instead of testing the built library, which includes UMD, we only test the library itself. This should increase the reported coverage quite a bit given how small the library is.
