### PR TITLE
Add "default" handlers for commands/requests

### DIFF
--- a/src/commands.js
+++ b/src/commands.js
@@ -9,6 +9,7 @@ Radio.Commands = {
   command: function(name) {
     var args = slice.call(arguments, 1);
     var channelName = this._channelName;
+    var commands = this._commands;
 
     // Check if we should log the request, and if so, do it
     if (channelName && this._tunedIn) {
@@ -16,8 +17,8 @@ Radio.Commands = {
     }
 
     // If the command isn't handled, log it in DEBUG mode and exit
-    if (this._commands && this._commands[name]) {
-      var handler = this._commands[name];
+    if (commands && (commands[name] || commands['default'])) {
+      var handler = commands[name] || commands['default'];
       handler.callback.apply(handler.context, args);
     } else {
       Radio._debugLog('An unhandled event was fired', name, channelName);

--- a/src/requests.js
+++ b/src/requests.js
@@ -13,6 +13,7 @@ Radio.Requests = {
   request: function(name) {
     var args = slice.call(arguments, 1);
     var channelName = this._channelName;
+    var requests = this._requests;
 
     // Check if we should log the request, and if so, do it
     if (channelName && this._tunedIn) {
@@ -20,8 +21,8 @@ Radio.Requests = {
     }
 
     // If the request isn't handled, log it in DEBUG mode and exit
-    if (this._requests && this._requests[name]) {
-      var handler = this._requests[name];
+    if (requests && (requests[name] || requests['default'])) {
+      var handler = requests[name] || requests['default'];
       return handler.callback.apply(handler.context, args);
     } else {
       Radio._debugLog('An unhandled event was fired', name, channelName);

--- a/test/spec/commands.js
+++ b/test/spec/commands.js
@@ -17,6 +17,23 @@ describe('Commands:', function() {
         .to.have.been.calledOnce
         .and.to.have.always.returned(this.Commands);
     });
+
+    describe('but has a "default" handler', function() {
+      beforeEach(function() {
+        this.callbackStub = this.sinon.stub();
+        this.argumentOne = 'argOne';
+        this.argumentTwo = 'argTwo';
+
+        this.Commands.comply('default', this.callbackStub);
+        this.Commands.command('handlerDoesNotExist', this.argumentOne, this.argumentTwo);
+      });
+
+      it('should pass along the arguments to the "default" handler.', function() {
+        expect(this.callbackStub)
+          .to.have.been.calledOnce
+          .and.calledWithExactly(this.argumentOne, this.argumentTwo);
+      });
+    });
   });
 
   describe('when commanding an action that has a handler', function() {
@@ -109,6 +126,18 @@ describe('Commands:', function() {
         .to.have.been.calledOnce
         .and.to.have.always.returned(this.Commands);
     });
+
+    describe('and has a "default" handler', function() {
+      beforeEach(function() {
+        this.defaultCallbackStub = this.sinon.stub();
+        this.Commands.comply('default', this.defaultCallbackStub);
+        this.Commands.command(this.actionName);
+      });
+
+      it('should not call the "default" handler', function() {
+        expect(this.defaultCallbackStub).not.have.been.called;
+      });
+    });
   });
 
   describe('when commanding an action multiple times that has a `once` handler', function() {
@@ -120,27 +149,51 @@ describe('Commands:', function() {
       this.callbackStub = this.sinon.stub();
 
       this.Commands.complyOnce(this.actionName, this.callbackStub);
-      this.Commands.command(this.actionName, this.argumentOne, this.argumentTwo);
-      this.Commands.command(this.actionName, this.argumentOne);
-      this.Commands.command(this.actionName, this.argumentTwo);
     });
 
-    it('should call the handler just once, passing the arguments.', function() {
-      expect(this.callbackStub)
-        .to.have.been.calledOnce
-        .and.calledWithExactly(this.argumentOne, this.argumentTwo);
+    describe('and has no "default" handler', function() {
+      beforeEach(function() {
+        this.Commands.command(this.actionName, this.argumentOne, this.argumentTwo);
+        this.Commands.command(this.actionName, this.argumentOne);
+        this.Commands.command(this.actionName, this.argumentTwo);
+      });
+
+      it('should call the handler just once, passing the arguments.', function() {
+        expect(this.callbackStub)
+          .to.have.been.calledOnce
+          .and.calledWithExactly(this.argumentOne, this.argumentTwo);
+      });
+
+      it('should always return the instance of Commands from `command`.', function() {
+        expect(this.commandSpy)
+          .to.have.been.calledThrice
+          .and.to.have.always.returned(this.Commands);
+      });
+
+      it('should always return the instance of Commands from `complyOnce`', function() {
+        expect(this.complyOnceSpy)
+          .to.have.been.calledOnce
+          .and.to.have.always.returned(this.Commands);
+      });
     });
 
-    it('should always return the instance of Commands from `command`.', function() {
-      expect(this.commandSpy)
-        .to.have.been.calledThrice
-        .and.to.have.always.returned(this.Commands);
-    });
+    describe('and has a "default" handler', function() {
+      beforeEach(function() {
+        this.defaultCallbackStub = this.sinon.stub();
 
-    it('should always return the instance of Commands from `complyOnce`', function() {
-      expect(this.complyOnceSpy)
-        .to.have.been.calledOnce
-        .and.to.have.always.returned(this.Commands);
+        this.Commands.comply('default', this.defaultCallbackStub);
+        this.Commands.command(this.actionName, this.argumentOne, this.argumentTwo);
+        this.Commands.command(this.actionName, this.argumentOne);
+        this.Commands.command(this.actionName, this.argumentTwo);
+      });
+
+      it('should call the "default" handler for subsequent calls', function() {
+        expect(this.defaultCallbackStub)
+          .to.have.been.calledTwice
+          .and.calledAfter(this.callbackStub)
+          .and.calledWithExactly(this.argumentOne)
+          .and.calledWithExactly(this.argumentTwo);
+      });
     });
   });
 


### PR DESCRIPTION
##### Resolves #82

Adds special keyword `default` to Requests and Commands so that when a request/command handler isn't registered it will be called instead.

In order to shave off some bytes I added aliases:

``` js
// Commands#command
var commands = this._commands;
// Requests#request
var requests = this._requests;
```
