### PR TITLE
Use src files in spec-runner.html

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -14,10 +14,6 @@ module.exports = function(grunt) {
       radio: {
         src: 'src/wrapper.js',
         dest: 'build/backbone.radio.js'
-      },
-      test: {
-        src: 'src/wrapper.js',
-        dest: '.tmp/backbone.radio.js'
       }
     },
 
@@ -126,7 +122,7 @@ module.exports = function(grunt) {
     },
   });
 
-  grunt.registerTask('test', 'Test the library', ['preprocess:test', 'jshint', 'mochaTest']);
+  grunt.registerTask('test', 'Test the library', ['jshint', 'mochaTest']);
 
   grunt.registerTask('coverage', 'Generate coverage report for the library', ['env:coverage', 'instrument', 'mochaTest', 'storeCoverage', 'makeReport', 'coveralls']);
 

--- a/test/spec-runner.html
+++ b/test/spec-runner.html
@@ -17,7 +17,14 @@
   <script src='../bower_components/backbone/backbone.js'></script>
 
   <!-- Load the library -->
-  <script src='../.tmp/backbone.radio.js'></script>
+  <script>var slice = Array.prototype.slice;</script>
+  <script src='../src/misc.js'></script>
+  <script src='../src/radio.js'></script>
+  <script src='../src/tune-in.js'></script>
+  <script src='../src/commands.js'></script>
+  <script src='../src/requests.js'></script>
+  <script src='../src/channel.js'></script>
+  <script src='../src/proxy.js'></script>
 
   <!-- Setup tests -->
   <script src='setup/helpers.js'></script>


### PR DESCRIPTION
Makes `preprocess:test` unnecessary.
