### PR TITLE
Add Events/Commands/Requests to Channel.prototype

### DIFF
--- a/src/channel.js
+++ b/src/channel.js
@@ -8,11 +8,10 @@
 
 Radio.Channel = function(channelName) {
   this._channelName = channelName;
-  _.extend(this, Backbone.Events, Radio.Commands, Radio.Requests);
   Radio._channels[channelName] = this;
 };
 
-_.extend(Radio.Channel.prototype, {
+_.extend(Radio.Channel.prototype, Backbone.Events, Radio.Commands, Radio.Requests, {
 
   // Remove all handlers from the messaging systems of this channel
   reset: function() {


### PR DESCRIPTION
This makes it so that they get mixed in at startup and not each time a Channel is created.
