### PR TITLE
Add actionName to first argument of default handler

### DIFF
--- a/src/commands.js
+++ b/src/commands.js
@@ -19,6 +19,7 @@ Radio.Commands = {
     // If the command isn't handled, log it in DEBUG mode and exit
     if (commands && (commands[name] || commands['default'])) {
       var handler = commands[name] || commands['default'];
+      args = commands[name] ? args : arguments;
       handler.callback.apply(handler.context, args);
     } else {
       Radio._debugLog('An unhandled event was fired', name, channelName);

--- a/src/requests.js
+++ b/src/requests.js
@@ -23,6 +23,7 @@ Radio.Requests = {
     // If the request isn't handled, log it in DEBUG mode and exit
     if (requests && (requests[name] || requests['default'])) {
       var handler = requests[name] || requests['default'];
+      args = requests[name] ? args : arguments;
       return handler.callback.apply(handler.context, args);
     } else {
       Radio._debugLog('An unhandled event was fired', name, channelName);

--- a/test/spec/commands.js
+++ b/test/spec/commands.js
@@ -9,7 +9,8 @@ describe('Commands:', function() {
 
   describe('when commanding an action that has no handler', function() {
     beforeEach(function() {
-      this.Commands.command('handlerDoesNotExist');
+      this.actionName = 'handlerDoesNotExist';
+      this.Commands.command(this.actionName);
     });
 
     it('should return the Commands object itself.', function() {
@@ -25,13 +26,13 @@ describe('Commands:', function() {
         this.argumentTwo = 'argTwo';
 
         this.Commands.comply('default', this.callbackStub);
-        this.Commands.command('handlerDoesNotExist', this.argumentOne, this.argumentTwo);
+        this.Commands.command(this.actionName, this.argumentOne, this.argumentTwo);
       });
 
       it('should pass along the arguments to the "default" handler.', function() {
         expect(this.callbackStub)
           .to.have.been.calledOnce
-          .and.calledWithExactly(this.argumentOne, this.argumentTwo);
+          .and.calledWithExactly(this.actionName, this.argumentOne, this.argumentTwo);
       });
     });
   });
@@ -191,8 +192,8 @@ describe('Commands:', function() {
         expect(this.defaultCallbackStub)
           .to.have.been.calledTwice
           .and.calledAfter(this.callbackStub)
-          .and.calledWithExactly(this.argumentOne)
-          .and.calledWithExactly(this.argumentTwo);
+          .and.calledWithExactly(this.actionName, this.argumentOne)
+          .and.calledWithExactly(this.actionName, this.argumentTwo);
       });
     });
   });

--- a/test/spec/requests.js
+++ b/test/spec/requests.js
@@ -10,7 +10,8 @@ describe('Requests:', function() {
 
   describe('when making a request that has no handler', function() {
     beforeEach(function() {
-      this.Requests.request('unhandledEvent');
+      this.actionName = 'unhandledEvent';
+      this.Requests.request(this.actionName);
     });
 
     it('should not return anything.', function() {
@@ -26,13 +27,13 @@ describe('Requests:', function() {
         this.argumentTwo = 'argTwo';
 
         this.Requests.reply('default', this.callbackStub);
-        this.Requests.request('unhandledEvent', this.argumentOne, this.argumentTwo);
+        this.Requests.request(this.actionName, this.argumentOne, this.argumentTwo);
       });
 
       it('should pass along the arguments to the "default" handler.', function() {
         expect(this.callbackStub)
           .to.have.been.calledOnce
-          .and.calledWithExactly(this.argumentOne, this.argumentTwo);
+          .and.calledWithExactly(this.actionName, this.argumentOne, this.argumentTwo);
       });
     });
   });
@@ -185,8 +186,8 @@ describe('Requests:', function() {
         expect(this.defaultCallbackStub)
           .to.have.been.calledTwice
           .and.calledAfter(this.callbackStub)
-          .and.calledWithExactly(this.argumentOne)
-          .and.calledWithExactly(this.argumentTwo);
+          .and.calledWithExactly(this.actionName, this.argumentOne)
+          .and.calledWithExactly(this.actionName, this.argumentTwo);
       });
     });
   });


### PR DESCRIPTION
Adds the command/request name to the arguments passed to the default handler. As per the comments in #84
