### PR TITLE
Use commands/requests instead of events for debug logs

### DIFF
--- a/src/commands.js
+++ b/src/commands.js
@@ -11,7 +11,7 @@ Radio.Commands = {
     var channelName = this.channelName;
     var commands = this._commands;
 
-    // Check if we should log the request, and if so, do it
+    // Check if we should log the command, and if so, do it
     if (channelName && this._tunedIn) {
       Radio.log.apply(this, [channelName, name].concat(args));
     }
@@ -21,7 +21,7 @@ Radio.Commands = {
       var handler = commands[name] || commands['default'];
       handler.callback.apply(handler.context, args);
     } else {
-      Radio._debugLog('An unhandled event was fired', name, channelName);
+      Radio._debugLog('An unhandled command was fired', name, channelName);
     }
 
     return this;

--- a/src/requests.js
+++ b/src/requests.js
@@ -25,7 +25,7 @@ Radio.Requests = {
       var handler = requests[name] || requests['default'];
       return handler.callback.apply(handler.context, args);
     } else {
-      Radio._debugLog('An unhandled event was fired', name, channelName);
+      Radio._debugLog('An unhandled request was fired', name, channelName);
     }
   },
 

--- a/test/spec/debug.js
+++ b/test/spec/debug.js
@@ -17,25 +17,25 @@ describe('DEBUG mode:', function() {
 
     it('should log a console warning when firing a command on a channel without a handler', function() {
       this.channel.command(this.eventName);
-      this.warning = 'An unhandled event was fired on the ' + this.channelName + ' channel: "' + this.eventName + '"';
+      this.warning = 'An unhandled command was fired on the ' + this.channelName + ' channel: "' + this.eventName + '"';
       expect(this.consoleStub).to.have.been.calledOnce.and.calledWithExactly(this.warning);
     });
 
     it('should log a console warning when firing a request on a channel without a handler', function() {
       this.channel.request(this.eventName);
-      this.warning = 'An unhandled event was fired on the ' + this.channelName + ' channel: "' + this.eventName + '"';
+      this.warning = 'An unhandled request was fired on the ' + this.channelName + ' channel: "' + this.eventName + '"';
       expect(this.consoleStub).to.have.been.calledOnce.and.calledWithExactly(this.warning);
     });
 
     it('should log a console warning when firing a command on an object without a handler', function() {
       this.Commands.command(this.eventName);
-      this.warning = 'An unhandled event was fired: "' + this.eventName + '"';
+      this.warning = 'An unhandled command was fired: "' + this.eventName + '"';
       expect(this.consoleStub).to.have.been.calledOnce.and.calledWithExactly(this.warning);
     });
 
     it('should log a console warning when firing a request on an object without a handler', function() {
       this.Requests.request(this.eventName);
-      this.warning = 'An unhandled event was fired: "' + this.eventName + '"';
+      this.warning = 'An unhandled request was fired: "' + this.eventName + '"';
       expect(this.consoleStub).to.have.been.calledOnce.and.calledWithExactly(this.warning);
     });
 


### PR DESCRIPTION
I think it'd be better to refer to these as requests and commands instead of events.
