### PR TITLE
Add Watch Task

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -120,13 +120,41 @@ module.exports = function(grunt) {
         src: 'coverage/lcov.info'
       }
     },
+
+    watch: {
+      tests: {
+        options: {
+          spawn: false
+        },
+        files: ['src/**/*.js', 'test/spec/**/*.js'],
+        tasks: ['test']
+      }
+    }
   });
 
-  grunt.registerTask('test', 'Test the library', ['jshint', 'mochaTest']);
+  grunt.registerTask('test', 'Test the library', [
+    'jshint',
+    'mochaTest'
+  ]);
 
-  grunt.registerTask('coverage', 'Generate coverage report for the library', ['env:coverage', 'instrument', 'mochaTest', 'storeCoverage', 'makeReport', 'coveralls']);
+  grunt.registerTask('coverage', 'Generate coverage report for the library', [
+    'env:coverage',
+    'instrument',
+    'mochaTest',
+    'storeCoverage',
+    'makeReport',
+    'coveralls'
+  ]);
 
-  grunt.registerTask('build', 'Build the library', ['test', 'preprocess:radio', 'template', 'concat', 'uglify']);
+  grunt.registerTask('build', 'Build the library', [
+    'test',
+    'preprocess:radio',
+    'template',
+    'concat',
+    'uglify'
+  ]);
 
-  grunt.registerTask('default', 'An alias of test', ['test']);
+  grunt.registerTask('default', 'An alias of test', [
+    'test'
+  ]);
 };

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "grunt-contrib-concat": "^0.4.0",
     "grunt-contrib-jshint": "^0.10.0",
     "grunt-contrib-uglify": "^0.4.0",
+    "grunt-contrib-watch": "^0.6.1",
     "grunt-coveralls": "^0.3.0",
     "grunt-env": "^0.4.1",
     "grunt-istanbul": "^0.3.0",


### PR DESCRIPTION
Adds `grunt watch` task for running `grunt test` on every file change.

I also moved the grunt task definitions to newline separated lists because they were driving me crazy.
