### PR TITLE
[WIP] Add a shim to use Radio with Marionette 2.1

### DIFF
--- a/extra/marionette-2.1.radio.shim.js
+++ b/extra/marionette-2.1.radio.shim.js
@@ -1,0 +1,23 @@
+(function(root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    define(['backbone.marionette', 'backbone.radio', 'underscore'], function(Marionette, Radio, _) {
+      return factory(Marionette, Radio);
+    });
+  }
+  else if (typeof exports !== 'undefined') {
+    var Marionette = require('backbone.marionette');
+    var Radio = require('backbone.radio');
+    var _ = require('underscore');
+    module.exports = factory(Marionette, Radio, _);
+  }
+  else {
+    factory(root.Backbone.Marionette, root.Backbone.Radio, root._);
+  }
+}(this, function(Marionette, Radio, _) {
+  'use strict';
+
+  Marionette.Application.prototype._initChannel = function () {
+    this.channelName = _.result(this, 'channelName') || 'global';
+    this.channel = _.result(this, 'channel') || Radio.channel(this.channelName);
+  }
+}));


### PR DESCRIPTION
This is a bare-bones shim to use Radio in Marionette v2.1.  I'm wondering if this should even be an officially supported thing. Maybe it would be best to just make it a gist and mention it in the Radio blog post?  If the shim is geared toward the cutting-edge crowd, I think an unofficial experimental gist might be easier in the long run.

So this shim could just say "here's one way to integrate Radio with Marionette. no promises that it will always work", since making sure something like this doesn't break seems like it could become a hassle.
