### PR TITLE
Stop Radio.Channel from touch Radio._channels

### DIFF
--- a/src/backbone.radio.js
+++ b/src/backbone.radio.js
@@ -101,7 +101,7 @@ _.extend(Radio, {
  */
 
 Radio.Commands = {
-  
+
   // Issue a command
   command: function(name) {
     var args = slice.call(arguments, 1);
@@ -276,7 +276,12 @@ Radio.channel = function(channelName) {
   if (!channelName) {
     throw new Error('You must provide a name for the channel.');
   }
-  return Radio._channels[channelName] || new Radio.Channel(channelName);
+
+  if (Radio._channels[channelName]) {
+    return Radio._channels[channelName];
+  } else {
+    return (Radio._channels[channelName] = new Radio.Channel(channelName));
+  }
 };
 
 /*
@@ -289,7 +294,6 @@ Radio.channel = function(channelName) {
 
 Radio.Channel = function(channelName) {
   this.channelName = channelName;
-  Radio._channels[channelName] = this;
 };
 
 _.extend(Radio.Channel.prototype, Backbone.Events, Radio.Commands, Radio.Requests, {


### PR DESCRIPTION
This makes it so `new Radio.Channel` won't touch `Radio._channels` at all. Previously calling `new Radio.Channel` with the same name twice would lead to a conflict on `Radio._channels`.

The `Radio.channel` factory still behaves the same way, but is much more self-contained.
