### PR TITLE
Add support for space-separated commands/requests

### DIFF
--- a/test/spec/commands.js
+++ b/test/spec/commands.js
@@ -345,4 +345,56 @@ describe('Commands:', function() {
         .and.calledWith('commandTwo');
     });
   });
+
+  describe('when calling `command` with space-separated commands', function() {
+    beforeEach(function() {
+      this.Commands.command('commandOne commandTwo', 'argOne', 'argTwo');
+    });
+
+    it('should call `command` with the correct commands', function() {
+      expect(this.Commands.command)
+        .to.have.been.calledThrice
+        .and.calledWith('commandOne', 'argOne', 'argTwo')
+        .and.calledWith('commandTwo', 'argOne', 'argTwo');
+    });
+  });
+
+  describe('when calling `comply` with space-separated commands', function() {
+    beforeEach(function() {
+      this.Commands.comply('commandOne commandTwo', 'argOne', 'argTwo');
+    });
+
+    it('should call `comply` with the correct commands', function() {
+      expect(this.Commands.comply)
+        .to.have.been.calledThrice
+        .and.calledWith('commandOne', 'argOne', 'argTwo')
+        .and.calledWith('commandTwo', 'argOne', 'argTwo');
+    });
+  });
+
+  describe('when calling `complyOnce` with space-separated commands', function() {
+    beforeEach(function() {
+      this.Commands.complyOnce('commandOne commandTwo', 'argOne', 'argTwo');
+    });
+
+    it('should call `complyOnce` with the correct commands', function() {
+      expect(this.Commands.complyOnce)
+        .to.have.been.calledThrice
+        .and.calledWith('commandOne', 'argOne', 'argTwo')
+        .and.calledWith('commandTwo', 'argOne', 'argTwo');
+    });
+  });
+
+  describe('when calling `stopComplying` with space-separated commands', function() {
+    beforeEach(function() {
+      this.Commands.stopComplying('commandOne commandTwo');
+    });
+
+    it('should call `stopComplying` with the correct commands', function() {
+      expect(this.Commands.stopComplying)
+        .to.have.been.calledThrice
+        .and.calledWith('commandOne')
+        .and.calledWith('commandTwo');
+    });
+  });
 });

--- a/test/spec/requests.js
+++ b/test/spec/requests.js
@@ -265,6 +265,29 @@ describe('Requests:', function() {
     });
   });
 
+  describe('when calling `request` with object', function() {
+    beforeEach(function() {
+      this.Requests.reply('requestOne', 'replyOne');
+      this.Requests.reply('requestTwo', 'replyTwo');
+      this.Requests.request({
+        'requestOne' : 'argOne',
+        'requestTwo' : 'argTwo'
+      });
+    });
+
+    it('should call the set of requests', function() {
+      expect(this.Requests.request)
+        .to.have.been.calledThrice
+        .and.calledWith('requestOne', 'argOne')
+        .and.calledWith('requestTwo', 'argTwo');
+    });
+
+    it('should return an array of replies', function() {
+      expect(this.Requests.request)
+        .to.have.returned(['replyOne', 'replyTwo']);
+    });
+  });
+
   describe('when calling `reply` with object', function() {
     beforeEach(function() {
       this.requestOneStub = stub();
@@ -328,6 +351,65 @@ describe('Requests:', function() {
     });
 
     it('should call the set of requests', function() {
+      expect(this.Requests.stopReplying)
+        .to.have.been.calledThrice
+        .and.calledWith('requestOne')
+        .and.calledWith('requestTwo');
+    });
+  });
+
+  describe('when calling `request` with space-separated requests', function() {
+    beforeEach(function() {
+      this.Requests.reply('requestOne', 'replyOne');
+      this.Requests.reply('requestTwo', 'replyTwo');
+      this.Requests.request('requestOne requestTwo', 'argOne', 'argTwo');
+    });
+
+    it('should call `request` with the correct requests', function() {
+      expect(this.Requests.request)
+        .to.have.been.calledThrice
+        .and.calledWith('requestOne', 'argOne', 'argTwo')
+        .and.calledWith('requestTwo', 'argOne', 'argTwo');
+    });
+
+    it('should return an array of replies', function() {
+      expect(this.Requests.request)
+        .to.have.returned(['replyOne', 'replyTwo']);
+    });
+  });
+
+  describe('when calling `reply` with space-separated requests', function() {
+    beforeEach(function() {
+      this.Requests.reply('requestOne requestTwo', 'argOne', 'argTwo');
+    });
+
+    it('should call `reply` with the correct requests', function() {
+      expect(this.Requests.reply)
+        .to.have.been.calledThrice
+        .and.calledWith('requestOne', 'argOne', 'argTwo')
+        .and.calledWith('requestTwo', 'argOne', 'argTwo');
+    });
+  });
+
+  describe('when calling `replyOnce` with space-separated requests', function() {
+    beforeEach(function() {
+      this.Requests.replyOnce('requestOne requestTwo', 'argOne', 'argTwo');
+    });
+
+    it('should call `replyOnce` with the correct requests', function() {
+      expect(this.Requests.replyOnce)
+        .to.have.been.calledThrice
+        .and.calledWith('requestOne', 'argOne', 'argTwo')
+        .and.calledWith('requestTwo', 'argOne', 'argTwo');
+    });
+  });
+
+  describe('when calling `stopReplying` with space-separated requests', function() {
+    beforeEach(function() {
+      this.Requests.stopReplying('requestOne requestTwo');
+    });
+
+    it('should call `stopReplying` with the correct requests', function() {
       expect(this.Requests.stopReplying)
         .to.have.been.calledThrice
         .and.calledWith('requestOne')


### PR DESCRIPTION
Resolves #96

Also adds `eventApi` support to `request`!
