### PR TITLE
Remove use of _.constant to support underscore@1.4.4 #163

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "github": "https://github.com/marionettejs/backbone.radio",
   "dependencies": {
     "backbone": ">=0.9.9 <=1.1.2",
-    "underscore": ">=1.6.0 <=1.7.0"
+    "underscore": ">=1.4.4 <=1.7.0"
   },
   "devDependencies": {
     "chai": "^1.9.1",

--- a/src/backbone.radio.js
+++ b/src/backbone.radio.js
@@ -244,7 +244,7 @@ Radio.Commands = {
  */
 
 function makeCallback(callback) {
-  return _.isFunction(callback) ? callback : _.constant(callback);
+  return _.isFunction(callback) ? callback : function () { return callback; };
 }
 
 Radio.Requests = {


### PR DESCRIPTION
Testing that it works with underscore@1.4.4

``` shell
npm install backbone@1.1.0
npm install underscore@1.4.4
grunt
```

Not sure if we can automate this in travis.
