### PR TITLE
add getChannels method

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,12 @@ var profileChannel = Backbone.Radio.channel('profile');
 var settingsChannel = Backbone.Radio.channel('settings');
 ```
 
+You are able to access the full list of channels available using the `getChannel` method. This can be useful when you have many subscribing channels listening to one main event publisher and you need to iterate over available channels in Radio.
+
+```js
+var channels = Backbone.Radio.getChannels();
+```
+
 The whole point of Channels is that they provide a way to explicitly namespace events in your application. It gives you greater
 control over which objects are able to talk to one another.
 

--- a/src/backbone.radio.js
+++ b/src/backbone.radio.js
@@ -349,6 +349,10 @@ Radio.channel = function(channelName) {
   }
 };
 
+Radio.getChannels = function() {
+  return Radio._channels;
+};
+
 /*
  * Backbone.Radio.Channel
  * ----------------------

--- a/test/spec/form.js
+++ b/test/spec/form.js
@@ -15,6 +15,10 @@ describe('When Radio is attached to your application', function() {
     expect(Backbone.Radio.channel).to.exist;
   });
 
+  it('should have the getChannels method', function() {
+    expect(Backbone.Radio.getChannels).to.exist;
+  });
+
   it('should have the Channel Class attached to it', function() {
     expect(Backbone.Radio.Channel).to.exist;
   });

--- a/test/spec/top-level.js
+++ b/test/spec/top-level.js
@@ -4,6 +4,13 @@ describe('Top-level API:', function() {
     stub(this.channel);
   });
 
+  describe('when excuting the getChannels method', function () {
+    it('should return the full list of channels', function() {
+      var channels = Backbone.Radio.getChannels();
+      expect(channels.myChannel).to.exist;
+    });
+  });
+
   describe('when executing Commands methods', function() {
     beforeEach(function() {
       Backbone.Radio.comply('myChannel', 'some:command', 'firstArg1', 'secondArg1');


### PR DESCRIPTION
@jmeas as discussed here is a PR adding a `getChannels` method. Our use case is that we split out app up into many components but we only what each component to listen/comply on their own channel. Radio has been great for us tidying up our nest of events!

One thing we have noticed is that a lot of our components need to comply or listen to the same events. We have one message broker which publishes down each radio channel for the components that need it. Currently our publisher can end up looking like this:

```
gameNext: function (data) {
    gameInfoChannel.command('startGame', data);
    ticketsChannel.command('startGame', data);
    bonusesChannel.command('startGame', data);
    callsChannel.command('startGame', data);
    chatChannel.command('startGame', data);
    prizesChannel.command('startGame', data);
}
```

Sometimes with more channels needing the command. We can tidy this up by doing:

```
_.each(Radio._channels, function (channel) {
    channel.command('startGame', data);
});
```

Only problem is this is private so don't really wanna do that - hence the `getChannels` method. A second option would be to create an engine channel which all components listen to but Im quite keen to keep components isolated and don't want to encourage the use of a 'global' channel.