### PR TITLE
Fix request result when using both the object and space-separated syntaxes at once

### DIFF
--- a/src/backbone.radio.js
+++ b/src/backbone.radio.js
@@ -45,7 +45,8 @@ function eventsApi(obj, action, name, rest) {
   // Handle event maps.
   if (typeof name === 'object') {
     for (var key in name) {
-      results.push(obj[action].apply(obj, [key, name[key]].concat(rest)));
+      var result = obj[action].apply(obj, [key, name[key]].concat(rest));
+      eventSplitter.test(key) ? (results = results.concat(result)) : results.push(result);
     }
     return results;
   }

--- a/test/spec/requests.js
+++ b/test/spec/requests.js
@@ -512,4 +512,29 @@ describe('Requests:', function() {
         .and.calledWith('requestTwo');
     });
   });
+
+  describe('when calling `request` with object with space-separated keys of requests', function() {
+    beforeEach(function() {
+      this.Requests.reply('requestOne', 'replyOne');
+      this.Requests.reply('requestTwo', 'replyTwo');
+      this.Requests.reply('requestThree', 'replyThree');
+      this.Requests.request({
+        'requestOne requestTwo' : 'argOne',
+        'requestThree' : 'argTwo'
+      });
+    });
+
+    it('should call the set of requests', function() {
+      expect(this.Requests.request)
+        .to.have.callCount(5)
+        .and.calledWith('requestOne', 'argOne')
+        .and.calledWith('requestTwo', 'argOne')
+        .and.calledWith('requestThree', 'argTwo');
+    });
+
+    it('should return an array of replies', function() {
+      expect(this.Requests.request)
+        .to.have.returned(['replyOne', 'replyTwo', 'replyThree']);
+    });
+  });
 });


### PR DESCRIPTION
#196