### PR TITLE
Move BB and _ to peerDependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ bower install backbone.radio
 npm install backbone.radio
 ```
 
+You must also ensure that Backbone.Radio's dependencies on Underscore (or Lodash) and Backbone are installed.
+
 ## Documentation
 
 - [Getting Started](#getting-started)

--- a/bower.json
+++ b/bower.json
@@ -25,9 +25,5 @@
     "bower_components",
     "test",
     "tests"
-  ],
-  "dependencies": {
-    "backbone": "1.0.0 - 1.3.2",
-    "underscore": "1.4.4 - 1.8.3"
-  }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "url": "https://github.com/marionettejs/backbone.radio.git"
   },
   "github": "https://github.com/marionettejs/backbone.radio",
-  "dependencies": {
+  "peerDependencies": {
     "backbone": "1.0.0 - 1.3.2",
     "underscore": "1.4.4 - 1.8.3"
   },
@@ -52,6 +52,7 @@
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-es2015-rollup": "^1.1.1",
     "babel-register": "^6.3.13",
+    "backbone": "1.0.0 - 1.3.2",
     "chai": "^3.4.1",
     "del": "^2.2.0",
     "glob": "^6.0.3",
@@ -78,6 +79,7 @@
     "rollup-plugin-babel": "^2.4.0",
     "sinon": "^1.17.2",
     "sinon-chai": "^2.8.0",
+    "underscore": "1.4.4 - 1.8.3",
     "webpack": "^1.12.9",
     "webpack-stream": "^3.1.0"
   },


### PR DESCRIPTION
To satisfy Mn 3.0's requirement to move deps to peerDeps this should go into an RC to pull into the next Mn 3.0 rc