### PR TITLE
Remove banner comment from minified sourcemap

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -106,8 +106,8 @@ function build(done) {
       .pipe($.rename(exportFileName + '.min.js'))
       .pipe($.sourcemaps.init({ loadMaps: true }))
       .pipe($.uglify())
-      .pipe($.sourcemaps.write('./'))
       .pipe($.header(banner))
+      .pipe($.sourcemaps.write('./'))
       .pipe(gulp.dest(destinationFolder))
       .on('end', done);
   }).catch(console.error);


### PR DESCRIPTION
Was causing parse issues (at least in Chrome). i.e.:
`Failed to parse SourceMap: /bower_components/backbone.radio/build/backbone.radio.min.js.map`

![image](https://cloud.githubusercontent.com/assets/1666298/16274148/58105956-3872-11e6-828c-aebeae470b4b.png)
