### PR TITLE
add: console.trace() for easier debugging

### DIFF
--- a/src/backbone.radio.js
+++ b/src/backbone.radio.js
@@ -33,6 +33,9 @@ Radio._debugText = function(warning, eventName, channelName) {
 Radio.debugLog = function(warning, eventName, channelName) {
   if (Radio.DEBUG && console && console.warn) {
     console.warn(Radio._debugText(warning, eventName, channelName));
+    if (console.trace) {
+      console.trace();
+    }
   }
 };
 


### PR DESCRIPTION
Hey,

sometimes it's hard to tell where does the event come from, console.trace() would be really helpful.

We could also add a Radio.TRACE flag if necessary.